### PR TITLE
nitpicks: Fix copyright year and a bit of syntax

### DIFF
--- a/content/sponsors.md
+++ b/content/sponsors.md
@@ -12,38 +12,38 @@ There is only one thing we want to tell them.
 **Thank you!**
 
 <div id="sponsors_top">
-    <img src="/img/sponsors/erigones_big_as_deserved.png" alt="Erigones"></img>
-    <img src="/img/sponsors/topolcany.jpg" alt="Mesto Topoľčany"></img>
-    <img src="/img/sponsors/tribecska.png" alt="Základná škola Tribečská"></img>
-    <img src="/img/sponsors/sam.png" alt="SAM - Shipbuilding and Machinery"></img>
-    <img src="https://github.global.ssl.fastly.net/images/modules/logos_page/Octocat.png" style="width: 200px;" alt="GitHub"></img>
+    <img src="/img/sponsors/erigones_big_as_deserved.png" alt="Erigones">
+    <img src="/img/sponsors/topolcany.jpg" alt="Mesto Topoľčany">
+    <img src="/img/sponsors/tribecska.png" alt="Základná škola Tribečská">
+    <img src="/img/sponsors/sam.png" alt="SAM - Shipbuilding and Machinery">
+    <img src="https://github.global.ssl.fastly.net/images/modules/logos_page/Octocat.png" style="width: 200px;" alt="GitHub">
 </div>
 
 <div id="sponsors_scroller">
-    <img src="/img/sponsors/aquaclean.png" alt="Aquaclean"></img>
-    <img src="/img/sponsors/dinansi.jpg" alt="Dinansi"></img>
-    <img src="/img/sponsors/ferart.jpg" alt="Ferart"></img>
-    <img src="/img/sponsors/fornaxa.png" alt="Fornaxa"></img>
-    <img src="/img/sponsors/metas.jpg" alt="Metas"></img>
-    <img src="/img/sponsors/pmao.png" alt="Pmao"></img>
-    <img src="/img/sponsors/gmlink.jpg" alt="GM-Link"></img>
-    <img src="/img/sponsors/abcom.jpeg" alt="ab-com shop"></img>
-    <img src="/img/sponsors/zavodsky.jpg" alt="Distribúcia Závodský"></img>
-    <img src="/img/sponsors/mydva.jpg" alt="My Dva Group"></img>
-    <img src="/img/sponsors/dmpsteel.JPG" alt="D.M.P. STEEL"></img>
-    <img src="/img/sponsors/faxcopy.jpg" alt="FaxCOPY"></img>
-    <img src="/img/sponsors/marci.jpg" alt="Marci"></img>
-    <img src="/img/sponsors/mbnvercajch.jpg" alt="MBN vercajch"></img>
-    <img src="/img/sponsors/softec.png" alt="SOFTEC"></img>
-    <img src="/img/sponsors/storex.png" alt="STOREX"></img>
-    <img src="/img/sponsors/toptrans.png" alt="TopTrans"></img>
-    <img src="/img/sponsors/wittexplus.JPG" alt="WITTEX PLUS"></img>
-    <img src="/img/sponsors/dehnsohne.png" alt="DEHN + SOHNE"></img>
-    <img src="/img/sponsors/segafredo.png" alt="Segafredo Topoľčany"></img>
-    <img src="/img/sponsors/dominanz.png" alt="Dominanz"></img>
-    <img src="/img/sponsors/topgame.png" alt="TopGame"></img>
-    <img src="/img/sponsors/suavinex.png" alt="suavinex"></img>
-    <img src="/img/sponsors/erigones.png" alt="erigones"></img>
+    <img src="/img/sponsors/aquaclean.png" alt="Aquaclean">
+    <img src="/img/sponsors/dinansi.jpg" alt="Dinansi">
+    <img src="/img/sponsors/ferart.jpg" alt="Ferart">
+    <img src="/img/sponsors/fornaxa.png" alt="Fornaxa">
+    <img src="/img/sponsors/metas.jpg" alt="Metas">
+    <img src="/img/sponsors/pmao.png" alt="Pmao">
+    <img src="/img/sponsors/gmlink.jpg" alt="GM-Link">
+    <img src="/img/sponsors/abcom.jpeg" alt="ab-com shop">
+    <img src="/img/sponsors/zavodsky.jpg" alt="Distribúcia Závodský">
+    <img src="/img/sponsors/mydva.jpg" alt="My Dva Group">
+    <img src="/img/sponsors/dmpsteel.JPG" alt="D.M.P. STEEL">
+    <img src="/img/sponsors/faxcopy.jpg" alt="FaxCOPY">
+    <img src="/img/sponsors/marci.jpg" alt="Marci">
+    <img src="/img/sponsors/mbnvercajch.jpg" alt="MBN vercajch">
+    <img src="/img/sponsors/softec.png" alt="SOFTEC">
+    <img src="/img/sponsors/storex.png" alt="STOREX">
+    <img src="/img/sponsors/toptrans.png" alt="TopTrans">
+    <img src="/img/sponsors/wittexplus.JPG" alt="WITTEX PLUS">
+    <img src="/img/sponsors/dehnsohne.png" alt="DEHN + SOHNE">
+    <img src="/img/sponsors/segafredo.png" alt="Segafredo Topoľčany">
+    <img src="/img/sponsors/dominanz.png" alt="Dominanz">
+    <img src="/img/sponsors/topgame.png" alt="TopGame">
+    <img src="/img/sponsors/suavinex.png" alt="suavinex">
+    <img src="/img/sponsors/erigones.png" alt="erigones">
 </div>
 
 <script src="/js/libs/imageScroller.js"></script>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -69,7 +69,7 @@ Compatible" content="IE=edge,chrome=1">
         <a class="social vimeo" href="https://vimeo.com/xlcteam">Watch us on Vimeo</a>
     </div>
     <footer>
-      The XLC Team &copy 2012 - 2018 All Rights Reserved
+      The XLC Team &copy 2012 - 2019 All Rights Reserved
     </footer>
     <div style="clear: both"></div>
   </div>


### PR DESCRIPTION
* Change copyright year to actual year 2019
* Kramdown gem was throwing warnings about invalid closing tag </img>,
  that led to showing "</img>" after every image in the sponsors page

Signed-off-by: vargac <simon.varga123@gmail.com>